### PR TITLE
Add Playwright Tracing Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,20 @@ To configure Hercules in detail:
  
 For example: If you would like to run with a "Headful" browser, you can set the environment variable with ```export HEADLESS=false``` before triggering Hercules.
 
+- **How to Use Tracing in Playwright**
+
+  Tracing in Playwright allows you to analyze test executions and debug issues effectively. To enable tracing in your Playwright tests, follow these steps:
+
+  1. Ensure that tracing is enabled in the configuration.
+  2. Traces will be saved to the specified path: `{proof_path}/traces/trace.zip`.
+
+  #### Enabling Tracing
+
+  To enable tracing, set the following environment variable:
+
+  ```bash
+  export ENABLE_PLAYWRIGHT_TRACING=true
+  ```
 
 ### Understanding `agents_llm_config-example.json`
 

--- a/testzeus_hercules/config.py
+++ b/testzeus_hercules/config.py
@@ -181,6 +181,8 @@ class BaseConfigManager:
             "EXECUTE_BULK",
         ]
 
+        relevant_keys.append("ENABLE_PLAYWRIGHT_TRACING")
+
         for key in relevant_keys:
             if key in os.environ:
                 self._config[key] = os.environ[key]
@@ -262,6 +264,7 @@ class BaseConfigManager:
         self._config.setdefault("GEO_API_KEY", None)
         self._config.setdefault("REACTION_DELAY_TIME", "0.1")
         self._config.setdefault("EXECUTE_BULK", "false")
+        self._config.setdefault("ENABLE_PLAYWRIGHT_TRACING", "false")
 
         if self._config["MODE"] == "debug":
             self.timestamp = "0"
@@ -327,6 +330,10 @@ class BaseConfigManager:
     def should_execute_bulk(self) -> bool:
         """Return whether tests should be executed in bulk mode"""
         return self._config["EXECUTE_BULK"].lower().strip() == "true"
+
+    def should_enable_tracing(self) -> bool:
+        """Check if Playwright tracing should be enabled"""
+        return self._config.get("ENABLE_PLAYWRIGHT_TRACING", "false").lower() == "true"
 
     # -------------------------------------------------------------------------
     # Directory creation logic (mirroring your original code)


### PR DESCRIPTION
### Feature: Add Playwright Tracing Feature

This PR introduces Playwright tracing support, enhancing debugging and test analysis capabilities.

**How to Enable:**
- Set the environment variable `ENABLE_PLAYWRIGHT_TRACING=true`.
- Traces will be saved to `{proof_path}/traces/trace.zip`.

**Reference Issue:** [#31](https://github.com/test-zeus-ai/testzeus-hercules/issues/31)
