### PR TITLE
feat: add IGNORE_CERTIFICATE_ERRORS env flag

### DIFF
--- a/tests/test_certificate_errors.py
+++ b/tests/test_certificate_errors.py
@@ -1,0 +1,101 @@
+import pytest
+import os
+from unittest.mock import patch, AsyncMock
+from testzeus_hercules.config import SingletonConfigManager, set_global_conf, get_global_conf
+from testzeus_hercules.core.playwright_manager import PlaywrightManager
+
+
+class TestCertificateErrors:
+    """Basic test suite for IGNORE_CERTIFICATE_ERRORS functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        """Setup and teardown for each test."""
+        os.environ["IS_TEST_ENV"] = "true"
+
+        SingletonConfigManager.reset_instance()
+        yield
+        SingletonConfigManager.reset_instance()
+
+    def test_should_ignore_certificate_errors_default_false(self):
+        """Test that should_ignore_certificate_errors returns False by default."""
+        if "IGNORE_CERTIFICATE_ERRORS" in os.environ:
+            del os.environ["IGNORE_CERTIFICATE_ERRORS"]
+
+        config = set_global_conf({"IGNORE_CERTIFICATE_ERRORS": "false", "LLM_MODEL_NAME": "test-model", "LLM_MODEL_API_KEY": "test-key"}, ignore_env=True)
+        assert config.should_ignore_certificate_errors() is False
+
+    def test_should_ignore_certificate_errors_true(self):
+        """Test that should_ignore_certificate_errors returns True when set to 'true'."""
+        os.environ["IGNORE_CERTIFICATE_ERRORS"] = "true"
+
+        config = set_global_conf({"IGNORE_CERTIFICATE_ERRORS": "true", "LLM_MODEL_NAME": "test-model", "LLM_MODEL_API_KEY": "test-key"}, ignore_env=True)
+        assert config.should_ignore_certificate_errors() is True
+
+    def test_should_ignore_certificate_errors_case_insensitive(self):
+        """Test that should_ignore_certificate_errors is case insensitive."""
+        os.environ["IGNORE_CERTIFICATE_ERRORS"] = "TRUE"
+        config = set_global_conf({"IGNORE_CERTIFICATE_ERRORS": "TRUE", "LLM_MODEL_NAME": "test-model", "LLM_MODEL_API_KEY": "test-key"}, ignore_env=True)
+        assert config.should_ignore_certificate_errors() is True
+
+        os.environ["IGNORE_CERTIFICATE_ERRORS"] = "True"
+        config = set_global_conf({"IGNORE_CERTIFICATE_ERRORS": "True", "LLM_MODEL_NAME": "test-model", "LLM_MODEL_API_KEY": "test-key"}, ignore_env=True)
+        assert config.should_ignore_certificate_errors() is True
+
+    def test_should_ignore_certificate_errors_missing_key(self):
+        """Test that should_ignore_certificate_errors returns False when key is missing."""
+        if "IGNORE_CERTIFICATE_ERRORS" in os.environ:
+            del os.environ["IGNORE_CERTIFICATE_ERRORS"]
+
+        config = set_global_conf({"LLM_MODEL_NAME": "test-model", "LLM_MODEL_API_KEY": "test-key"}, ignore_env=True)
+        assert config.should_ignore_certificate_errors() is False
+
+    def test_environment_variable_override(self):
+        """Test that environment variable IGNORE_CERTIFICATE_ERRORS overrides config."""
+        os.environ["IGNORE_CERTIFICATE_ERRORS"] = "true"
+
+        config_dict = {"IGNORE_CERTIFICATE_ERRORS": "false", "AGENTS_LLM_CONFIG_FILE": "agents_llm_config.json", "AGENTS_LLM_CONFIG_FILE_REF_KEY": "azure"}
+        config = set_global_conf(config_dict, ignore_env=False)
+
+        assert config.should_ignore_certificate_errors() is True
+
+    def test_playwright_manager_with_certificate_errors_enabled(self):
+        """Test that PlaywrightManager includes certificate error flags when enabled."""
+        os.environ["IGNORE_CERTIFICATE_ERRORS"] = "true"
+
+        config_dict = {
+            "IGNORE_CERTIFICATE_ERRORS": "true",
+            "BROWSER_TYPE": "chromium",
+            "HEADLESS": "true",
+            "RECORD_VIDEO": "false",
+            "TAKE_SCREENSHOTS": "false",
+            "CAPTURE_NETWORK": "false",
+            "LLM_MODEL_NAME": "test-model",
+            "LLM_MODEL_API_KEY": "test-key",
+        }
+
+        set_global_conf(config_dict, ignore_env=True)
+
+        config = get_global_conf()
+        assert config.should_ignore_certificate_errors() is True
+
+    def test_playwright_manager_with_certificate_errors_disabled(self):
+        """Test that PlaywrightManager does NOT include certificate error flags when disabled."""
+        if "IGNORE_CERTIFICATE_ERRORS" in os.environ:
+            del os.environ["IGNORE_CERTIFICATE_ERRORS"]
+
+        config_dict = {
+            "IGNORE_CERTIFICATE_ERRORS": "false",
+            "BROWSER_TYPE": "chromium",
+            "HEADLESS": "true",
+            "RECORD_VIDEO": "false",
+            "TAKE_SCREENSHOTS": "false",
+            "CAPTURE_NETWORK": "false",
+            "LLM_MODEL_NAME": "test-model",
+            "LLM_MODEL_API_KEY": "test-key",
+        }
+
+        set_global_conf(config_dict, ignore_env=True)
+
+        config = get_global_conf()
+        assert config.should_ignore_certificate_errors() is False

--- a/testzeus_hercules/config.py
+++ b/testzeus_hercules/config.py
@@ -345,6 +345,7 @@ class BaseConfigManager:
             "TAKE_SCREENSHOTS",
             "CAPTURE_NETWORK",
             "CDP_ENDPOINT_URL",
+            "IGNORE_CERTIFICATE_ERRORS",
             # LLM model configuration
             "LLM_MODEL_NAME",
             "LLM_MODEL_API_KEY",
@@ -715,6 +716,10 @@ class BaseConfigManager:
     def should_skip_wait_for_load_state(self) -> bool:
         """Return whether to skip wait_for_load_state calls."""
         return self._config["NO_WAIT_FOR_LOAD_STATE"].lower().strip() == "true"
+
+    def should_ignore_certificate_errors(self) -> bool:
+        """Check if certificate errors should be ignored during browser launch."""
+        return self._config.get("IGNORE_CERTIFICATE_ERRORS", "false").lower() == "true"
 
     # -------------------------------------------------------------------------
     # Directory creation logic (mirroring your original code)

--- a/testzeus_hercules/core/playwright_manager.py
+++ b/testzeus_hercules/core/playwright_manager.py
@@ -85,9 +85,7 @@ class PlaywrightManager:
     _default_instance: Optional["PlaywrightManager"] = None
     _homepage = "about:blank"
 
-    def __new__(
-        cls, *args, stake_id: Optional[str] = None, **kwargs
-    ) -> "PlaywrightManager":
+    def __new__(cls, *args, stake_id: Optional[str] = None, **kwargs) -> "PlaywrightManager":
         # If no stake_id provided and we have a default instance, return it
         if stake_id is None:
             if cls._default_instance is None:
@@ -96,9 +94,7 @@ class PlaywrightManager:
                 instance.__initialized = False
                 cls._default_instance = instance
                 cls._instances["0"] = instance
-                logger.debug(
-                    "Created default PlaywrightManager instance with stake_id '0'"
-                )
+                logger.debug("Created default PlaywrightManager instance with stake_id '0'")
             return cls._default_instance
 
         # If stake_id provided, get or create instance for that stake_id
@@ -106,9 +102,7 @@ class PlaywrightManager:
             instance = super().__new__(cls)
             instance.__initialized = False
             cls._instances[stake_id] = instance
-            logger.debug(
-                f"Created new PlaywrightManager instance for stake_id '{stake_id}'"
-            )
+            logger.debug(f"Created new PlaywrightManager instance for stake_id '{stake_id}'")
             # If this is the first instance ever, make it the default
             if cls._default_instance is None:
                 cls._default_instance = instance
@@ -163,9 +157,7 @@ class PlaywrightManager:
         take_screenshots: Optional[bool] = None,
         cdp_config: Optional[Dict] = None,
         cdp_reuse_tabs: Optional[bool] = False,  # New parameter to control tab reuse
-        cdp_navigate_on_connect: Optional[
-            bool
-        ] = True,  # New parameter to control navigation
+        cdp_navigate_on_connect: Optional[bool] = True,  # New parameter to control navigation
         record_video: Optional[bool] = None,
         video_dir: Optional[str] = None,
         log_requests_responses: Optional[bool] = None,
@@ -175,9 +167,7 @@ class PlaywrightManager:
         viewport: Optional[Tuple[int, int]] = None,
         locale: Optional[str] = None,
         timezone: Optional[str] = None,  # e.g. "America/New_York"
-        geolocation: Optional[
-            Dict[str, float]
-        ] = None,  # {"latitude": 51.5, "longitude": -0.13}
+        geolocation: Optional[Dict[str, float]] = None,  # {"latitude": 51.5, "longitude": -0.13}
         color_scheme: Optional[str] = None,  # "light", "dark", "no-preference"
         allow_all_permissions: bool = True,
         log_console: Optional[bool] = None,
@@ -203,11 +193,7 @@ class PlaywrightManager:
         self.stake_id = stake_id or "0"
 
         # Video recording settings
-        self._record_video = (
-            record_video
-            if record_video is not None
-            else get_global_conf().should_record_video()
-        )
+        self._record_video = record_video if record_video is not None else get_global_conf().should_record_video()
         self._latest_video_path: Optional[str] = None
         self._video_dir: Optional[str] = None
 
@@ -216,51 +202,25 @@ class PlaywrightManager:
         # ----------------------
         # 1) BROWSER / HEADLESS
         # ----------------------
-        self.browser_type = (
-            browser_type or get_global_conf().get_browser_type() or "chromium"
-        )
-        self.browser_channel = (
-            browser_channel or get_global_conf().get_browser_channel()
-        )
+        self.browser_type = browser_type or get_global_conf().get_browser_type() or "chromium"
+        self.browser_channel = browser_channel or get_global_conf().get_browser_channel()
         self.browser_path = browser_path or get_global_conf().get_browser_path()
-        self.browser_version = (
-            browser_version or get_global_conf().get_browser_version()
-        )
-        self.isheadless = (
-            headless
-            if headless is not None
-            else get_global_conf().should_run_headless()
-        )
+        self.browser_version = browser_version or get_global_conf().get_browser_version()
+        self.isheadless = headless if headless is not None else get_global_conf().should_run_headless()
         self.cdp_config = cdp_config or get_global_conf().get_cdp_config()
 
         # CDP behavior settings
         config = get_global_conf()
-        self.cdp_reuse_tabs = (
-            cdp_reuse_tabs
-            if cdp_reuse_tabs is not None
-            else getattr(config, "cdp_reuse_tabs", True)
-        )
-        self.cdp_navigate_on_connect = (
-            cdp_navigate_on_connect
-            if cdp_navigate_on_connect is not None
-            else getattr(config, "cdp_navigate_on_connect", False)
-        )
+        self.cdp_reuse_tabs = cdp_reuse_tabs if cdp_reuse_tabs is not None else getattr(config, "cdp_reuse_tabs", True)
+        self.cdp_navigate_on_connect = cdp_navigate_on_connect if cdp_navigate_on_connect is not None else getattr(config, "cdp_navigate_on_connect", False)
 
         # ----------------------
         # 2) BASIC FLAGS
         # ----------------------
         self.notification_manager = NotificationManager()
         self.user_response_future: Optional[asyncio.Future[str]] = None
-        self._take_screenshots = (
-            take_screenshots
-            if take_screenshots is not None
-            else get_global_conf().should_take_screenshots()
-        )
-        self._take_bounding_box_screenshots = (
-            take_bounding_box_screenshots
-            if take_bounding_box_screenshots is not None
-            else get_global_conf().should_take_bounding_box_screenshots()
-        )
+        self._take_screenshots = take_screenshots if take_screenshots is not None else get_global_conf().should_take_screenshots()
+        self._take_bounding_box_screenshots = take_bounding_box_screenshots if take_bounding_box_screenshots is not None else get_global_conf().should_take_bounding_box_screenshots()
         self.stake_id = stake_id
 
         # ----------------------
@@ -281,11 +241,7 @@ class PlaywrightManager:
         # ----------------------
         # 4) LOGS
         # ----------------------
-        self.log_requests_responses = (
-            log_requests_responses
-            if log_requests_responses is not None
-            else get_global_conf().should_capture_network()
-        )
+        self.log_requests_responses = log_requests_responses if log_requests_responses is not None else get_global_conf().should_capture_network()
         self.request_response_logs: List[Dict] = []
 
         # ----------------------
@@ -297,9 +253,7 @@ class PlaywrightManager:
         self._latest_screenshot_bytes: Optional[bytes] = None
 
         # Extension caching directory
-        self._extension_cache_dir = os.path.join(
-            ".", ".cache", "browser", self.browser_type, "extension"
-        )
+        self._extension_cache_dir = os.path.join(".", ".cache", "browser", self.browser_type, "extension")
         self._extension_path: Optional[str] = None
 
         # ----------------------
@@ -316,9 +270,7 @@ class PlaywrightManager:
 
         self.user_locale = locale or get_global_conf().get_locale()  # or None
         self.user_timezone = timezone or get_global_conf().get_timezone()  # or None
-        self.user_geolocation = (
-            geolocation or get_global_conf().get_geolocation()
-        )  # or None
+        self.user_geolocation = geolocation or get_global_conf().get_geolocation()  # or None
         self.user_color_scheme = color_scheme or get_global_conf().get_color_scheme()
 
         # Get browser cookies from config
@@ -326,9 +278,7 @@ class PlaywrightManager:
 
         # If iPhone, override browser
         if self.device_name and "iphone" in self.device_name.lower():
-            logger.info(
-                f"Detected iPhone in device_name='{self.device_name}'; forcing browser_type=webkit."
-            )
+            logger.info(f"Detected iPhone in device_name='{self.device_name}'; forcing browser_type=webkit.")
             self.browser_type = "webkit"
 
         # logging console messages
@@ -386,9 +336,7 @@ class PlaywrightManager:
         """
         # Skip if extensions are disabled in config
         if not get_global_conf().should_enable_ublock_extension():
-            logger.info(
-                "uBlock extension is disabled in config. Skipping installation."
-            )
+            logger.info("uBlock extension is disabled in config. Skipping installation.")
             return
 
         if os.name == "nt":
@@ -396,17 +344,11 @@ class PlaywrightManager:
             return
 
         if self.browser_type == "chromium":
-            extension_url = (
-                "https://github.com/gorhill/uBlock/releases/download/1.61.0/"
-                "uBlock0_1.61.0.chromium.zip"
-            )
+            extension_url = "https://github.com/gorhill/uBlock/releases/download/1.61.0/" "uBlock0_1.61.0.chromium.zip"
             extension_file_name = "uBlock0_1.61.0.chromium.zip"
             extension_dir_name = "uBlock0_1.61.0.chromium"
         elif self.browser_type == "firefox":
-            extension_url = (
-                "https://addons.mozilla.org/firefox/downloads/file/4359936/"
-                "ublock_origin-1.60.0.xpi"
-            )
+            extension_url = "https://addons.mozilla.org/firefox/downloads/file/4359936/" "ublock_origin-1.60.0.xpi"
             extension_file_name = "uBlock0_1.60.0.firefox.xpi"
             extension_dir_name = "uBlock0_1.60.0.firefox"
         else:
@@ -429,14 +371,9 @@ class PlaywrightManager:
                         await asyncio.to_thread(lambda: open(path, "wb").write(content))
 
                     await write_file_async(extension_file_path, response.content)
-                    logger.info(
-                        f"Extension downloaded and saved to {extension_file_path}"
-                    )
+                    logger.info(f"Extension downloaded and saved to {extension_file_path}")
                 else:
-                    logger.error(
-                        f"Failed to download extension from {extension_url}, "
-                        f"status {response.status_code}"
-                    )
+                    logger.error(f"Failed to download extension from {extension_url}, " f"status {response.status_code}")
                     return
 
         if self.browser_type == "chromium":
@@ -447,9 +384,7 @@ class PlaywrightManager:
                     with zipfile.ZipFile(zip_path, "r") as zip_ref:
                         zip_ref.extractall(extract_dir)
 
-                await asyncio.to_thread(
-                    unzip_archive, extension_file_path, extension_unzip_dir
-                )
+                await asyncio.to_thread(unzip_archive, extension_file_path, extension_unzip_dir)
             self._extension_path = extension_unzip_dir + "/uBlock0.chromium"
         elif self.browser_type == "firefox":
             self._extension_path = extension_file_path
@@ -497,6 +432,15 @@ class PlaywrightManager:
             "--disable-features=IsolateOrigins,site-per-process",
         ]
 
+        if get_global_conf().should_ignore_certificate_errors():
+            logger.info("Certificate error ignoring is enabled for browser context via IGNORE_CERTIFICATE_ERRORS environment variable")
+            disable_args.extend(
+                [
+                    "--ignore-certificate-errors",
+                    "--ignore-ssl-errors",
+                ]
+            )
+
         if not self.device_name:
             w, h = self.user_viewport
             disable_args.append(f"--window-size={w},{h}")
@@ -515,9 +459,7 @@ class PlaywrightManager:
                 _browser = await browser_type.connect(endpoint_url, timeout=120000)
                 recording_supported = False
             else:
-                _browser = await browser_type.connect_over_cdp(
-                    endpoint_url, timeout=120000
-                )
+                _browser = await browser_type.connect_over_cdp(endpoint_url, timeout=120000)
 
             # Prepare context options
             context_options = {}
@@ -551,10 +493,7 @@ class PlaywrightManager:
                         logger.info(f"Found usable page {idx} with URL: {current_url}")
 
                         # Skip about:blank pages if there are better options
-                        if (
-                            current_url not in ["about:blank", "chrome://newtab/"]
-                            or usable_page is None
-                        ):
+                        if current_url not in ["about:blank", "chrome://newtab/"] or usable_page is None:
                             usable_page = p
                             # If we found a non-empty page, prefer that one
                             if current_url not in ["about:blank", "chrome://newtab/"]:
@@ -565,9 +504,7 @@ class PlaywrightManager:
                         logger.debug(f"Page {idx} not usable: {e}")
 
                 if usable_page:
-                    logger.info(
-                        f"Reusing existing page with URL: {await usable_page.evaluate('window.location.href')}"
-                    )
+                    logger.info(f"Reusing existing page with URL: {await usable_page.evaluate('window.location.href')}")
                     page = usable_page
 
                     try:
@@ -578,16 +515,12 @@ class PlaywrightManager:
                         # Don't let bring_to_front failures block us
 
                         traceback.print_exc()
-                        logger.warning(
-                            f"Failed to bring page to front, but continuing: {e}"
-                        )
+                        logger.warning(f"Failed to bring page to front, but continuing: {e}")
                 else:
                     logger.info("No usable existing pages found. Creating new page.")
                     page = await self._browser_context.new_page()
             else:
-                logger.info(
-                    "Creating new page as no existing pages found or reuse disabled."
-                )
+                logger.info("Creating new page as no existing pages found or reuse disabled.")
                 page = await self._browser_context.new_page()
 
             # Only navigate if explicitly configured to do so
@@ -602,12 +535,8 @@ class PlaywrightManager:
                     current_url = await page.evaluate("window.location.href")
                     if current_url in ["about:blank", "chrome://newtab/"]:
                         logger.info("Setting minimal HTML content for empty tab")
-                        await page.set_content(
-                            "<html><body><h1>Connected via TestZeus Hercules</h1><p>Tab is ready for automation.</p></body></html>"
-                        )
-                        logger.info(
-                            f"Tab content set, current URL: {await page.evaluate('window.location.href')}"
-                        )
+                        await page.set_content("<html><body><h1>Connected via TestZeus Hercules</h1><p>Tab is ready for automation.</p></body></html>")
+                        logger.info(f"Tab content set, current URL: {await page.evaluate('window.location.href')}")
                 except Exception as e:
 
                     traceback.print_exc()
@@ -619,19 +548,22 @@ class PlaywrightManager:
 
         else:
             if self.browser_type != "chromium":
-                disable_args = []
+                certificate_args = []
+                if get_global_conf().should_ignore_certificate_errors():
+                    logger.info("Certificate error ignoring is enabled for non-chromium browser via IGNORE_CERTIFICATE_ERRORS environment variable")
+                    certificate_args = [
+                        "--ignore-certificate-errors",
+                        "--ignore-ssl-errors",
+                    ]
+                disable_args = certificate_args
 
             browser_type = getattr(self._playwright, self.browser_type)
             await self.prepare_extension()
 
             if self._record_video:
-                await self._launch_browser_with_video(
-                    browser_type, user_dir, disable_args
-                )
+                await self._launch_browser_with_video(browser_type, user_dir, disable_args)
             else:
-                await self._launch_persistent_browser(
-                    browser_type, user_dir, disable_args
-                )
+                await self._launch_persistent_browser(browser_type, user_dir, disable_args)
 
         # Start tracing only once after browser context is created
         await self._start_tracing()
@@ -648,9 +580,7 @@ class PlaywrightManager:
             if device:
                 context_options.update(device)
             else:
-                logger.warning(
-                    f"Device '{self.device_name}' not found in Playwright devices."
-                )
+                logger.warning(f"Device '{self.device_name}' not found in Playwright devices.")
         else:
             # Set viewport manually if no device
             context_options["viewport"] = {
@@ -683,18 +613,11 @@ class PlaywrightManager:
         user_dir: str,
         disable_args: Optional[List[str]] = None,
     ) -> None:
-        channel_info = (
-            f" (channel: {self.browser_channel})" if self.browser_channel else ""
-        )
-        version_info = (
-            f" (version: {self.browser_version})" if self.browser_version else ""
-        )
+        channel_info = f" (channel: {self.browser_channel})" if self.browser_channel else ""
+        version_info = f" (version: {self.browser_version})" if self.browser_version else ""
         path_info = f" (custom path: {self.browser_path})" if self.browser_path else ""
 
-        logger.info(
-            f"Launching {self.browser_type}{channel_info}{version_info}{path_info} "
-            f"with video recording enabled."
-        )
+        logger.info(f"Launching {self.browser_type}{channel_info}{version_info}{path_info} " f"with video recording enabled.")
         temp_user_dir = tempfile.mkdtemp(prefix="playwright-user-data-")
         # copy user_dir to temp in a separate thread
         if user_dir and os.path.exists(user_dir):
@@ -704,9 +627,7 @@ class PlaywrightManager:
 
         try:
             if self.browser_type == "chromium" and self._extension_path is not None:
-                disable_args.append(
-                    f"--disable-extensions-except={self._extension_path}"
-                )
+                disable_args.append(f"--disable-extensions-except={self._extension_path}")
                 disable_args.append(f"--load-extension={self._extension_path}")
 
             launch_options = {
@@ -782,18 +703,20 @@ class PlaywrightManager:
         if disable_args is None:
             disable_args = []
 
-        channel_info = (
-            f" (channel: {self.browser_channel})" if self.browser_channel else ""
-        )
-        version_info = (
-            f" (version: {self.browser_version})" if self.browser_version else ""
-        )
+        if get_global_conf().should_ignore_certificate_errors():
+            logger.info("Certificate error ignoring is enabled for persistent browser via IGNORE_CERTIFICATE_ERRORS environment variable")
+            disable_args.extend(
+                [
+                    "--ignore-certificate-errors",
+                    "--ignore-ssl-errors",
+                ]
+            )
+
+        channel_info = f" (channel: {self.browser_channel})" if self.browser_channel else ""
+        version_info = f" (version: {self.browser_version})" if self.browser_version else ""
         path_info = f" (custom path: {self.browser_path})" if self.browser_path else ""
 
-        logger.info(
-            f"Launching {self.browser_type}{channel_info}{version_info}{path_info} "
-            f"with user dir: {user_dir}"
-        )
+        logger.info(f"Launching {self.browser_type}{channel_info}{version_info}{path_info} " f"with user dir: {user_dir}")
 
         try:
             browser_context_kwargs = {
@@ -851,9 +774,7 @@ class PlaywrightManager:
             if self.browser_version:
                 try:
                     # Install the specific version before launching
-                    install_command = (
-                        f"playwright install {self.browser_type}@{self.browser_version}"
-                    )
+                    install_command = f"playwright install {self.browser_type}@{self.browser_version}"
                     logger.info(f"Installing browser version: {install_command}")
                     process = await asyncio.create_subprocess_shell(
                         install_command,
@@ -862,9 +783,7 @@ class PlaywrightManager:
                     )
                     stdout, stderr = await process.communicate()
                     if process.returncode != 0:
-                        logger.error(
-                            f"Failed to install browser version: {stderr.decode()}"
-                        )
+                        logger.error(f"Failed to install browser version: {stderr.decode()}")
                 except Exception as e:
 
                     traceback.print_exc()
@@ -875,15 +794,11 @@ class PlaywrightManager:
             browser_context_kwargs.update(self._build_emulation_context_options())
 
             if self.browser_type == "chromium" and self._extension_path is not None:
-                disable_args.append(
-                    f"--disable-extensions-except={self._extension_path}"
-                )
+                disable_args.append(f"--disable-extensions-except={self._extension_path}")
                 disable_args.append(f"--load-extension={self._extension_path}")
             elif self.browser_type == "firefox" and self._extension_path is not None:
                 # Merge with existing firefox_user_prefs if any
-                firefox_user_prefs = browser_context_kwargs.get(
-                    "firefox_user_prefs", {}
-                )
+                firefox_user_prefs = browser_context_kwargs.get("firefox_user_prefs", {})
                 firefox_user_prefs.update(
                     {
                         "xpinstall.signatures.required": False,
@@ -899,9 +814,7 @@ class PlaywrightManager:
                 )
                 browser_context_kwargs["firefox_user_prefs"] = firefox_user_prefs
 
-            self._browser_context = await browser_type.launch_persistent_context(
-                user_dir, **browser_context_kwargs
-            )
+            self._browser_context = await browser_type.launch_persistent_context(user_dir, **browser_context_kwargs)
 
             # Add cookies if provided
             await self._add_cookies_if_provided()
@@ -918,10 +831,7 @@ class PlaywrightManager:
     ) -> None:
         if "Target page, context or browser has been closed" in str(e):
             new_user_dir = tempfile.mkdtemp()
-            logger.error(
-                f"Failed to launch persistent context with user dir {user_dir}: {e}. "
-                f"Trying with a new user dir {new_user_dir}"
-            )
+            logger.error(f"Failed to launch persistent context with user dir {user_dir}: {e}. " f"Trying with a new user dir {new_user_dir}")
             launch_options = {
                 "headless": self.isheadless,
                 "args": args or [],
@@ -945,23 +855,15 @@ class PlaywrightManager:
             if self.browser_path:
                 launch_options["executable_path"] = self.browser_path
 
-            self._browser_context = await browser_type.launch_persistent_context(
-                new_user_dir, **launch_options
-            )
+            self._browser_context = await browser_type.launch_persistent_context(new_user_dir, **launch_options)
 
             # Add cookies if provided
             await self._add_cookies_if_provided()
 
         elif any(err in str(e) for err in ["is not found", "Executable doesn't exist"]):
-            channel_info = (
-                f" (channel: {self.browser_channel})" if self.browser_channel else ""
-            )
-            version_info = (
-                f" (version: {self.browser_version})" if self.browser_version else ""
-            )
-            path_info = (
-                f" (custom path: {self.browser_path})" if self.browser_path else ""
-            )
+            channel_info = f" (channel: {self.browser_channel})" if self.browser_channel else ""
+            version_info = f" (version: {self.browser_version})" if self.browser_version else ""
+            path_info = f" (custom path: {self.browser_path})" if self.browser_path else ""
 
             browser_name = {
                 "chromium": "Chrome",
@@ -1000,9 +902,7 @@ class PlaywrightManager:
             else:
                 decoded_post_data = post_data
         except Exception as e:
-            logger.warning(
-                f"Failed to decode post data for browser API request: {e} for request {request}"
-            )
+            logger.warning(f"Failed to decode post data for browser API request: {e} for request {request}")
             decoded_post_data = None
 
         log_entry = {
@@ -1014,9 +914,7 @@ class PlaywrightManager:
             "post_data": decoded_post_data,
         }
         # Instead of writing directly, do it via asyncio
-        asyncio.ensure_future(
-            self._write_log_entry_to_file(log_entry, self.request_response_log_file)
-        )
+        asyncio.ensure_future(self._write_log_entry_to_file(log_entry, self.request_response_log_file))
 
     def log_response(self, response: Any) -> None:
         log_entry = {
@@ -1027,9 +925,7 @@ class PlaywrightManager:
             "headers": response.headers,
             "body": None,
         }
-        asyncio.ensure_future(
-            self._write_log_entry_to_file(log_entry, self.request_response_log_file)
-        )
+        asyncio.ensure_future(self._write_log_entry_to_file(log_entry, self.request_response_log_file))
 
     async def _write_log_entry_to_file(self, log_entry: Dict, log_file: str) -> None:
         """Write a single log entry asynchronously."""
@@ -1110,20 +1006,14 @@ class PlaywrightManager:
         async def set_iframe_navigation_handlers() -> None:
             for frame in page.frames:
                 if frame != page.main_frame:
-                    frame.on(
-                        "domcontentloaded", handle_navigation_for_mutation_observer
-                    )
+                    frame.on("domcontentloaded", handle_navigation_for_mutation_observer)
 
         await set_iframe_navigation_handlers()
 
-        await page.expose_function(
-            "dom_mutation_change_detected", dom_mutation_change_detected
-        )
+        await page.expose_function("dom_mutation_change_detected", dom_mutation_change_detected)
         page.on(
             "frameattached",
-            lambda frame: frame.on(
-                "domcontentloaded", handle_navigation_for_mutation_observer
-            ),
+            lambda frame: frame.on("domcontentloaded", handle_navigation_for_mutation_observer),
         )
 
     async def highlight_element(self, selector: str) -> None:
@@ -1177,9 +1067,7 @@ class PlaywrightManager:
         screenshot_path = os.path.join(self.get_screenshots_dir(), screenshot_name)
 
         try:
-            await self.wait_for_load_state_if_enabled(
-                page=page, state=load_state, timeout=take_snapshot_timeout
-            )
+            await self.wait_for_load_state_if_enabled(page=page, state=load_state, timeout=take_snapshot_timeout)
             screenshot_bytes = await page.screenshot(
                 path=screenshot_path,
                 full_page=full_page,
@@ -1227,24 +1115,14 @@ class PlaywrightManager:
                             else:
                                 video_name = os.path.basename(video_path)
                             video_dir = os.path.dirname(video_path)
-                            safe_url = (
-                                page.url.replace("://", "_")
-                                .replace("/", "_")
-                                .replace(".", "_")
-                                if not page.url
-                                else "video_of"
-                            )
-                            new_video_path = os.path.join(
-                                video_dir, f"{safe_url}_{video_name}"
-                            )
+                            safe_url = page.url.replace("://", "_").replace("/", "_").replace(".", "_") if not page.url else "video_of"
+                            new_video_path = os.path.join(video_dir, f"{safe_url}_{video_name}")
 
                             # rename asynchronously
                             def rename_file(src, dst):
                                 os.rename(src, dst)
 
-                            await asyncio.to_thread(
-                                rename_file, video_path, new_video_path
-                            )
+                            await asyncio.to_thread(rename_file, video_path, new_video_path)
                             self._latest_video_path = new_video_path
                             logger.info(f"Video recorded at {new_video_path}")
                     except Exception as e:
@@ -1276,9 +1154,7 @@ class PlaywrightManager:
     async def update_processing_state(self, processing_state: str) -> None:
         pass
 
-    async def command_completed(
-        self, command: str, elapsed_time: Optional[float] = None
-    ) -> None:
+    async def command_completed(self, command: str, elapsed_time: Optional[float] = None) -> None:
         logger.debug(f'Command "{command}" completed.')
 
     # -------------------------------------------------------------------------
@@ -1353,9 +1229,7 @@ class PlaywrightManager:
             if url.startswith(("data:", "blob:")):
                 return
             headers = request.headers
-            if headers.get("purpose") == "prefetch" or headers.get(
-                "sec-fetch-dest"
-            ) in ["video", "audio"]:
+            if headers.get("purpose") == "prefetch" or headers.get("sec-fetch-dest") in ["video", "audio"]:
                 return
             nonlocal last_activity
             pending_requests.add(request)
@@ -1400,14 +1274,10 @@ class PlaywrightManager:
             while True:
                 await asyncio.sleep(0.1)
                 now = asyncio.get_event_loop().time()
-                if (len(pending_requests) == 0) and (
-                    (now - last_activity) >= WAIT_FOR_NETWORK_IDLE
-                ):
+                if (len(pending_requests) == 0) and ((now - last_activity) >= WAIT_FOR_NETWORK_IDLE):
                     break
                 if now - start_time > MAX_WAIT_PAGE_LOAD_TIME:
-                    logger.debug(
-                        f"Network timeout after {MAX_WAIT_PAGE_LOAD_TIME}s with {len(pending_requests)} pending requests"
-                    )
+                    logger.debug(f"Network timeout after {MAX_WAIT_PAGE_LOAD_TIME}s with {len(pending_requests)} pending requests")
                     break
         finally:
             page.remove_listener("request", on_request)
@@ -1415,9 +1285,7 @@ class PlaywrightManager:
 
         logger.debug(f"Network stabilized for {WAIT_FOR_NETWORK_IDLE} ms")
 
-    async def wait_for_page_and_frames_load(
-        self, timeout_overwrite: Optional[float] = None
-    ) -> None:
+    async def wait_for_page_and_frames_load(self, timeout_overwrite: Optional[float] = None) -> None:
         """Wait for the page and all frames to load."""
         page = await self.get_current_page()
 
@@ -1490,9 +1358,7 @@ class PlaywrightManager:
         # Note: create_browser_context already calls _add_cookies_if_provided
         await self.go_to_homepage()
 
-    async def perform_javascript_click(
-        self, page: Page, selector: str, type_of_click: str
-    ) -> str:
+    async def perform_javascript_click(self, page: Page, selector: str, type_of_click: str) -> str:
         js_code = """(params) => {
             /*INJECT_FIND_ELEMENT_IN_SHADOW_DOM*/
             const selector = params[0];
@@ -1662,28 +1528,18 @@ class PlaywrightManager:
         }"""
 
         try:
-            logger.info(
-                f"Executing JavaScript '{type_of_click}' on element with selector: {selector}"
-            )
-            result: str = await page.evaluate(
-                get_js_with_element_finder(js_code), (selector, type_of_click)
-            )
-            logger.debug(
-                f"Executed JavaScript '{type_of_click}' on element with selector: {selector}"
-            )
+            logger.info(f"Executing JavaScript '{type_of_click}' on element with selector: {selector}")
+            result: str = await page.evaluate(get_js_with_element_finder(js_code), (selector, type_of_click))
+            logger.debug(f"Executed JavaScript '{type_of_click}' on element with selector: {selector}")
             return result
         except Exception as e:
 
             traceback.print_exc()
-            logger.error(
-                f"Error executing JavaScript '{type_of_click}' on element with selector: {selector}. Error: {e}"
-            )
+            logger.error(f"Error executing JavaScript '{type_of_click}' on element with selector: {selector}. Error: {e}")
             traceback.print_exc()
             return f"Error executing JavaScript '{type_of_click}' on element with selector: {selector}"
 
-    async def is_element_present(
-        self, selector: str, page: Optional[Page] = None
-    ) -> bool:
+    async def is_element_present(self, selector: str, page: Optional[Page] = None) -> bool:
         """Check if an element is present in DOM/Shadow DOM/iframes."""
         if page is None:
             page = await self.get_current_page()
@@ -1722,9 +1578,7 @@ class PlaywrightManager:
         element = await page.query_selector(selector)
         if element:
             if self._take_bounding_box_screenshots:
-                await self._capture_element_with_bbox(
-                    element, page, selector, element_name
-                )
+                await self._capture_element_with_bbox(element, page, selector, element_name)
             return element
 
         # Check Shadow DOM and iframes
@@ -1733,16 +1587,12 @@ class PlaywrightManager:
             return findElementInShadowDOMAndIframes(document, selector);
         }"""
 
-        element = await page.evaluate_handle(
-            get_js_with_element_finder(js_code), selector
-        )
+        element = await page.evaluate_handle(get_js_with_element_finder(js_code), selector)
         if element:
             element_handle = element.as_element()
             if element_handle:
                 if self._take_bounding_box_screenshots:
-                    await self._capture_element_with_bbox(
-                        element_handle, page, selector, element_name
-                    )
+                    await self._capture_element_with_bbox(element_handle, page, selector, element_name)
             return element_handle
 
         return None
@@ -1843,9 +1693,7 @@ class PlaywrightManager:
             line_height = 22  # Original 20 + 10%
 
             # Calculate text dimensions with word wrapping
-            max_width = min(
-                image.width * 0.4, 400
-            )  # Reduced from 500px to 400px for better wrapping
+            max_width = min(image.width * 0.4, 400)  # Reduced from 500px to 400px for better wrapping
             wrapped_lines = []
 
             for text in metadata:
@@ -1856,9 +1704,7 @@ class PlaywrightManager:
                     current_line = url_prefix
 
                     # Break URL into segments of reasonable length
-                    segment_length = (
-                        40  # Adjust this value to control URL segment length
-                    )
+                    segment_length = 40  # Adjust this value to control URL segment length
                     start = 0
                     while start < len(url_text):
                         end = start + segment_length
@@ -1905,9 +1751,7 @@ class PlaywrightManager:
             bg_color = (0, 0, 0, 128)
             bg_layer = Image.new("RGBA", image.size, (0, 0, 0, 0))
             bg_draw = ImageDraw.Draw(bg_layer)
-            bg_draw.rectangle(
-                [bg_x, bg_y, bg_x + bg_width, bg_y + bg_height], fill=bg_color
-            )
+            bg_draw.rectangle([bg_x, bg_y, bg_x + bg_width, bg_y + bg_height], fill=bg_color)
 
             # Composite the background onto the main image
             image = Image.alpha_composite(image.convert("RGBA"), bg_layer)
@@ -1916,15 +1760,11 @@ class PlaywrightManager:
             # Draw wrapped text
             current_y = bg_y + text_padding
             for line in wrapped_lines:
-                draw.text(
-                    (bg_x + text_padding, current_y), line, fill="white", font=font
-                )
+                draw.text((bg_x + text_padding, current_y), line, fill="white", font=font)
                 current_y += line_height
 
             # Save the modified screenshot
-            screenshot_path = os.path.join(
-                self.get_screenshots_dir(), f"{screenshot_name}.png"
-            )
+            screenshot_path = os.path.join(self.get_screenshots_dir(), f"{screenshot_name}.png")
 
             # Convert back to RGB before saving as PNG
             image = image.convert("RGB")
@@ -1937,9 +1777,7 @@ class PlaywrightManager:
 
             # Get element attributes and alternative selectors for logging
             element_attributes = await browser_logger.get_element_attributes(element)
-            alternative_selectors = await browser_logger.get_alternative_selectors(
-                element, page
-            )
+            alternative_selectors = await browser_logger.get_alternative_selectors(element, page)
 
             # Log the screenshot interaction
             await browser_logger.log_browser_interaction(
@@ -2000,9 +1838,7 @@ class PlaywrightManager:
             "location": msg.location,  # has 'url', 'lineNumber', 'columnNumber'
         }
         # Write asynchronously to console_log_file
-        asyncio.ensure_future(
-            self._write_log_entry_to_file(log_entry, self.console_log_file)
-        )
+        asyncio.ensure_future(self._write_log_entry_to_file(log_entry, self.console_log_file))
 
     async def _add_cookies_if_provided(self) -> None:
         """
@@ -2011,9 +1847,7 @@ class PlaywrightManager:
         """
         if self.browser_cookies and self._browser_context:
             try:
-                logger.info(
-                    f"Adding {len(self.browser_cookies)} cookies to browser context"
-                )
+                logger.info(f"Adding {len(self.browser_cookies)} cookies to browser context")
                 await self._browser_context.add_cookies(self.browser_cookies)
                 logger.info("Cookies added successfully")
             except Exception as e:
@@ -2089,9 +1923,7 @@ class PlaywrightManager:
                     except Exception as bring_err:
 
                         traceback.print_exc()
-                        logger.warning(
-                            f"Failed to bring tab to front, but continuing: {bring_err}"
-                        )
+                        logger.warning(f"Failed to bring tab to front, but continuing: {bring_err}")
 
                     return page
                 except Exception as tab_err:


### PR DESCRIPTION
### Summary :memo:
Add a global env flag to bypass and ignore browser certificate errors. [slack [thread](https://testzeuscommunityhq.slack.com/archives/C081GTY2T8V/p1754322588171869)]

### Details
1. Added `IGNORE_CERTIFICATE_ERRORS` as global env config to disable browser certificate errors.
2. Tested with flag = true, false
3. Tested with no flag - default = false

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
