### PR TITLE
Hotfix: add support for gpt-5

### DIFF
--- a/testzeus_hercules/core/config_env_loader.py
+++ b/testzeus_hercules/core/config_env_loader.py
@@ -8,6 +8,7 @@ from testzeus_hercules.core.agent_config_types import (
     ENV_TO_MODEL_CONFIG_MAPPING,
 )
 from testzeus_hercules.utils.logger import logger
+from testzeus_hercules.utils.llm_sanitizer import sanitize_llm_config_for_autogen
 
 
 class ConfigEnvLoader:
@@ -142,6 +143,7 @@ class ConfigEnvLoader:
 
         # Only add llm_config_params if we have values
         if llm_config_params:
+            llm_config_params = sanitize_llm_config_for_autogen(model_name, llm_config_params)
             normalized_config["llm_config_params"] = llm_config_params
 
         return normalized_config

--- a/testzeus_hercules/utils/llm_sanitizer.py
+++ b/testzeus_hercules/utils/llm_sanitizer.py
@@ -1,0 +1,13 @@
+from testzeus_hercules.utils.logger import logger
+from typing import Any
+
+def sanitize_llm_config_for_autogen(model_name: str, llm_config_params: dict[str, Any]) -> dict[str, Any]:
+    config = llm_config_params.copy()
+
+    if "gpt-5" in model_name.lower():
+        config["temperature"] = 1
+        config.pop("max_tokens", None)
+        config.pop("max_completion_tokens", None)
+        config.pop("presence_penalty", None)
+        config.pop("frequency_penalty", None)
+    return config


### PR DESCRIPTION
### Summary :memo:
> This hotfix adds support for gpt-5.

### Details
> Added function **sanitize_llm_config_for_autogen** for checking if model is gpt-5

### Bugfixes :bug:
- #67

### Checks
- [ ] Closes #67
- [ ] Tested Changes
- [ ] Stakeholder Approval
