### PR TITLE
refactor: Update LLM configuration for GPT-5 support

### DIFF
--- a/agents_llm_config-example.json
+++ b/agents_llm_config-example.json
@@ -95,52 +95,52 @@
             }
 		}
 	},
-    "openai_gpt5": {
-		"planner_agent": {
-			"model_name": "gpt-5",
-			"model_api_key": "",
-			"model_base_url": null,
-            "llm_config_params": {
-                "cache_seed": 1234,
-                "temperature": 0.0,
-                "max_completion_tokens": 4096,
-                "seed": 12345
-            }
-		},
-		"nav_agent": {
-            "model_name": "gpt-5-mini",
-			"model_api_key": "",
-			"model_base_url": null,
-            "llm_config_params": {
-                "cache_seed": 1234,
-                "temperature": 0.0,
-                "max_completion_tokens": 2048,
-                "seed": 12345
-            }
-		},
-		"mem_agent": {
-            "model_name": "gpt-5-nano",
-			"model_api_key": "",
-			"model_base_url": null,
-            "llm_config_params": {
-                "cache_seed": 1234,
-                "temperature": 0.0,
-                "max_completion_tokens": 1024,
-                "seed": 12345
-            }
-		},
-		"helper_agent": {
+    "openai-5": {
+        "planner_agent": {
             "model_name": "gpt-5",
-			"model_api_key": "",
-			"model_base_url": null,
+            "model_api_key": "",
+            "model_base_url": null,
             "llm_config_params": {
                 "cache_seed": 1234,
                 "temperature": 0.0,
                 "max_completion_tokens": 4096,
                 "seed": 12345
             }
-		}
-	},
+        },
+        "nav_agent": {
+            "model_name": "gpt-5-mini",
+            "model_api_key": "",
+            "model_base_url": null,
+            "llm_config_params": {
+                "cache_seed": 1234,
+                "temperature": 0.0,
+                "max_completion_tokens": 4096,
+                "seed": 12345
+            }
+        },
+        "mem_agent": {
+            "model_name": "gpt-5-mini",
+            "model_api_key": "",
+            "model_base_url": null,
+            "llm_config_params": {
+                "cache_seed": 1234,
+                "temperature": 0.0,
+                "max_completion_tokens": 4096,
+                "seed": 12345
+            }
+        },
+        "helper_agent": {
+            "model_name": "gpt-5-mini",
+            "model_api_key": "",
+            "model_base_url": null,
+            "llm_config_params": {
+                "cache_seed": 1234,
+                "temperature": 0.0,
+                "max_completion_tokens": 4096,
+                "seed": 12345
+            }
+        }
+    },
     "azure": {
 		"planner_agent": {
 			"model_name": "gpt-4o",

--- a/testzeus_hercules/core/agents_llm_config_manager.py
+++ b/testzeus_hercules/core/agents_llm_config_manager.py
@@ -8,6 +8,7 @@ from testzeus_hercules.core.agents_llm_config import AgentsLLMConfig
 from testzeus_hercules.core.config_env_loader import ConfigEnvLoader
 from testzeus_hercules.core.config_file_loader import ConfigFileLoader
 from testzeus_hercules.core.config_portkey_loader import PortkeyConfigLoader
+from testzeus_hercules.utils.model_utils import adapt_llm_params_for_model
 from testzeus_hercules.utils.logger import logger
 
 
@@ -331,6 +332,8 @@ class AgentsLLMConfigManager:
                 )
                 logger.info(f"Using Portkey with API type: {model_api_type}, provider: {provider}")
             return portkey_config
+        
+        config["llm_config_params"] = adapt_llm_params_for_model(config["model_config_params"]["model"], config["model_config_params"])
 
         return config
 

--- a/testzeus_hercules/core/simple_hercules.py
+++ b/testzeus_hercules/core/simple_hercules.py
@@ -6,7 +6,7 @@ import tempfile
 import traceback
 import uuid
 from string import Template
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 from testzeus_hercules.utils.model_utils import adapt_llm_params_for_model
 
 import autogen  # type: ignore
@@ -160,9 +160,6 @@ class SimpleHercules:
         self.nav_agent_config = nav_agent_config
         self.mem_agent_config = mem_agent_config
         self.helper_agent_config = helper_agent_config
-
-        # Adapt LLM parameters for all agents based on their model family
-        from testzeus_hercules.utils.model_utils import adapt_llm_params_for_model
         
         # Get model names for parameter adaptation
         planner_model = self.planner_agent_config["model_config_params"].get("model") or self.planner_agent_config["model_config_params"].get("model_name")
@@ -171,10 +168,10 @@ class SimpleHercules:
         helper_model = self.helper_agent_config["model_config_params"].get("model") or self.helper_agent_config["model_config_params"].get("model_name")
         
         # Adapt parameters for each agent
-        self.planner_agent_config["llm_config_params"] = adapt_llm_params_for_model(planner_model, self.planner_agent_config["llm_config_params"])
-        self.nav_agent_config["llm_config_params"] = adapt_llm_params_for_model(nav_model, self.nav_agent_config["llm_config_params"])
-        self.mem_agent_config["llm_config_params"] = adapt_llm_params_for_model(mem_model, self.mem_agent_config["llm_config_params"])
-        self.helper_agent_config["llm_config_params"] = adapt_llm_params_for_model(helper_model, self.helper_agent_config["llm_config_params"])
+        self.planner_agent_config["llm_config_params"] = adapt_llm_params_for_model(planner_model, self.planner_agent_config["model_config_params"])
+        self.nav_agent_config["llm_config_params"] = adapt_llm_params_for_model(nav_model, self.nav_agent_config["model_config_params"])
+        self.mem_agent_config["llm_config_params"] = adapt_llm_params_for_model(mem_model, self.mem_agent_config["model_config_params"])
+        self.helper_agent_config["llm_config_params"] = adapt_llm_params_for_model(helper_model, self.helper_agent_config["model_config_params"])
 
         self.planner_agent_model_config = convert_model_config_to_autogen_format(self.planner_agent_config["model_config_params"])
         self.browser_nav_agent_model_config = convert_model_config_to_autogen_format(self.nav_agent_config["model_config_params"])
@@ -404,9 +401,6 @@ class SimpleHercules:
                 cache=cache,
             )
         return self
-
-    from testzeus_hercules.utils.model_utils import adapt_llm_params_for_model
-
 
     def get_chat_logs_dir(self) -> str | None:
         """

--- a/testzeus_hercules/utils/model_utils.py
+++ b/testzeus_hercules/utils/model_utils.py
@@ -1,17 +1,17 @@
 import re
 from typing import Dict, Any
-from .logger import logger
+from testzeus_hercules.utils.logger import logger
 
 
-def _is_gpt5_model(model_name: str) -> bool:
+def _is_gpt_version_model(model_name: str, version: str) -> bool:
     """
     Check if the model is a GPT-5 variant using regex pattern.
     Matches: gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-2025-08-07, etc.
     """
-    return bool(re.match(r'^gpt-5', model_name))
+    return bool(re.match(f'^gpt-{version}', model_name))
 
 
-def adapt_llm_params_for_model(model_name: str, llm_config: Dict[str, Any]) -> Dict[str, Any]:
+def adapt_llm_params_for_model(model_name: str, model_config_params: Dict[str, Any]) -> Dict[str, Any]:
     """
     Normalize token-limit params for different providers/families.
     
@@ -19,28 +19,34 @@ def adapt_llm_params_for_model(model_name: str, llm_config: Dict[str, Any]) -> D
     For Claude models, converts max_tokens to max_tokens_to_sample.
     For other models, ensures max_tokens is present.
     """
-    params = dict(llm_config or {})
+    params = {}
 
-    if _is_gpt5_model(model_name):
-        # GPT-5 and newer models use max_completion_tokens
-        if "max_tokens" in params and "max_completion_tokens" not in params:
-            params["max_completion_tokens"] = params.pop("max_tokens")
-            logger.warning(
-                "Deprecated param 'max_tokens' supplied for %s; auto-translating to 'max_completion_tokens'.",
-                model_name,
-            )
-        # Remove/ignore temperature for GPT-5 (only default is supported by API)
-        if "temperature" in params:
-            if params["temperature"] not in (None, 1, 1.0):
+    if _is_gpt_version_model(model_name, ""):
+        # add api_key from model_config_params to llm_config_params
+        if "api_key" in model_config_params:
+            params["api_key"] = model_config_params["api_key"]
+        if _is_gpt_version_model(model_name, "5"):
+            # GPT-5 and newer models use max_completion_tokens
+            if "max_tokens" in params and "max_completion_tokens" not in params:
+                params["max_completion_tokens"] = params.pop("max_tokens")
                 logger.warning(
-                    "Model %s ignores non-default temperature=%s; removing to use API default (1).",
+                    "Deprecated param 'max_tokens' supplied for %s; auto-translating to 'max_completion_tokens'.",
                     model_name,
-                    params["temperature"],
                 )
-            params.pop("temperature", None)
-        # Set default if neither is present
-        if "max_completion_tokens" not in params:
-            params["max_completion_tokens"] = 4096
+            # Remove/ignore temperature for GPT-5 (only default is supported by API)
+            if "temperature" in params:
+                if params["temperature"] not in (None, 1, 1.0):
+                    logger.warning(
+                        "Model %s ignores non-default temperature=%s; removing to use API default (1).",
+                        model_name,
+                        params["temperature"],
+                    )
+                params.pop("temperature", None)
+            # Set default if neither is present
+            if "max_completion_tokens" not in params:
+                params["max_completion_tokens"] = 4096
+            
+            params['reasoning'] = {"effort": "low"}
 
     elif model_name.startswith(("claude", "anthropic")):
         # Claude models use max_tokens_to_sample


### PR DESCRIPTION
- Rename "openai_gpt5" to "openai-5" in the configuration file.
- Adjust max_completion_tokens for various agents to 4096.
- Update adapt_llm_params_for_model function to handle model configuration parameters more effectively.
- Remove redundant imports and clean up code in agents_llm_config_manager and simple_hercules modules.
- Enhance model_utils to support version-specific checks for GPT models.

This commit improves the handling of LLM parameters and ensures compatibility with the latest model configurations.
