### PR TITLE
fix(tools): add support for composite combobox elements

### DIFF
--- a/testzeus_hercules/core/tools/enter_text_using_selector.py
+++ b/testzeus_hercules/core/tools/enter_text_using_selector.py
@@ -147,8 +147,8 @@ async def do_entertext(page: Page, selector: str, text_to_enter: str, use_keyboa
         else:
             # Get element properties to determine the best selection strategy
             tag_name = await elem.evaluate("el => el.tagName.toLowerCase()")
-            element_role = await elem.evaluate("el => el.getAttribute('role') || ''")
-            element_type = await elem.evaluate("el => el.type || ''")
+            element_role = await elem.evaluate("el => (el.getAttribute && el.getAttribute('role')) || ''")
+            element_type = await elem.evaluate("el => (el.type || '').toLowerCase()")
             input_roles = ["combobox", "listbox", "dropdown", "spinner", "select"]
             input_types = [
                 "range",
@@ -160,6 +160,15 @@ async def do_entertext(page: Page, selector: str, text_to_enter: str, use_keyboa
                 "option",
             ]
             logger.info(f"element_role: {element_role}, element_type: {element_type}")
+
+        text_input_types = {"text", "search", "email", "password", "url", "tel", "number"}
+        is_text_entry_element = (
+            tag_name == "textarea" or
+            (tag_name == "input" and element_type in text_input_types) or
+            (element_role in {"textbox", "searchbox"})
+        )
+
+        if not is_text_entry_element:
             if element_role in input_roles or element_type in input_types:
                 properties = {
                     "tag_name": tag_name,


### PR DESCRIPTION
The agent is unable to perform text entry on critical web elements that are not simple input tags. A prime example is the Google search bar, which is a composite <div> structure where the typable element is identified by its ARIA role (textbox or searchbox).

Failing Test Case:

```
Feature: Google Search

Scenario: Search for cat food
  Given I navigate to "[https://www.google.com](https://www.google.com)"
  Then A cookie page could appear
  Then If cookie page appeared close it by clicking on the Alle ablehnen button
  And I enter "Katzenfutter" in the search field
  And I click the button "Auf gut Glück!"
  Then I see a page about cat food

```

This test fails at the "enter 'Katzenfutter'" step because the old logic did not recognize the search bar as a valid text entry field.

Instead of narrowly targeting specific tags or the parent combobox role, the new solution adopts a more robust, purpose-driven approach by checking for standard ARIA roles that define a text input field.

```
- Fixes Text Entry on Modern Search Bars: The change allows the agent to correctly type into complex input fields, like the Google search bar, which it previously failed to recognize as a valid text entry element.

- Adds Support for Web Accessibility Standards (ARIA): It updates the code to identify elements based on their function (their ARIA role, such as textbox or searchbox) instead of just their HTML tag, making it compatible with a wider range of modern websites.
```
