### PR TITLE
Update model references to `gpt-5.4` across various helper scripts and configuration files

### DIFF
--- a/helper_scripts/cdp_journey_script.py
+++ b/helper_scripts/cdp_journey_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#python vir_migration_script.py raw_jsons/test1.json --output=output_txt --model=gpt-4o
+#python vir_migration_script.py raw_jsons/test1.json --output=output_txt --model=gpt-5.4
 
 
 import os
@@ -120,7 +120,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="JSON-in -> Gherkin-out script using OpenAI.")
     parser.add_argument("input_json", type=str, help="Path to the JSON file (Journey-like).")
     parser.add_argument("--output", type=str, required=True, help="Output folder for .feature files.")
-    parser.add_argument("--model", type=str, default="gpt-4o", help="OpenAI model name (default=gpt-4o).")
+    parser.add_argument("--model", type=str, default="gpt-5.4", help="OpenAI model name (default=gpt-5.4).")
     parser.add_argument(
         "--number_of_testcase",
         metavar="number_of_testcase",

--- a/helper_scripts/generate_api_functional_gherkin_test.py
+++ b/helper_scripts/generate_api_functional_gherkin_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # how to run
-# python helper_scripts/generate_api_functional_gherkin_test.py tests/test_features/ApiTesting/api_spec.yml --output=helper_scripts/output --model=gpt-4o --number_of_testcase=50
+# python helper_scripts/generate_api_functional_gherkin_test.py tests/test_features/ApiTesting/api_spec.yml --output=helper_scripts/output --model=gpt-5.4 --number_of_testcase=50
 
 import os
 import sys

--- a/helper_scripts/generate_api_security_gherkin_test.py
+++ b/helper_scripts/generate_api_security_gherkin_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # how to run
-# python helper_scripts/generate_api_security_gherkin_test.py tests/test_features/ApiTesting/api_spec.yml --output=helper_scripts/output --model=gpt-4o
+# python helper_scripts/generate_api_security_gherkin_test.py tests/test_features/ApiTesting/api_spec.yml --output=helper_scripts/output --model=gpt-5.4
 
 import os
 import sys
@@ -212,7 +212,7 @@ def main() -> None:
         "--model",
         metavar="model",
         type=str,
-        default="gpt-4o",
+        default="gpt-5.4",
         help="The model to use for the OpenAI API.",
     )
     args = parser.parse_args()

--- a/helper_scripts/run_hercules_docker.ps1
+++ b/helper_scripts/run_hercules_docker.ps1
@@ -97,7 +97,7 @@ if (-not (Test-Path "agents_llm_config.json")) {
     {
       "provider_name": "OpenAI",
       "api_key": "YOUR_API_KEY",
-      "model": "gpt-3.5-turbo"
+      "model": "gpt-5.4"
     }
   ]
 }

--- a/helper_scripts/vir_migration_script.py
+++ b/helper_scripts/vir_migration_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#python vir_migration_script.py raw_jsons/test1.json --output=output_txt --model=gpt-4o
+#python vir_migration_script.py raw_jsons/test1.json --output=output_txt --model=gpt-5.4
 
 
 import os
@@ -196,7 +196,7 @@ def main():
     parser = argparse.ArgumentParser(description="JSON-in -> Gherkin-out script using OpenAI.")
     parser.add_argument("input_json", type=str, help="Path to the JSON file (Virtuoso-like).")
     parser.add_argument("--output", type=str, required=True, help="Output folder for .feature files.")
-    parser.add_argument("--model", type=str, default="o1-preview", help="OpenAI model name (default=o1-preview).")
+    parser.add_argument("--model", type=str, default="gpt-5.4", help="OpenAI model name (default=gpt-5.4).")
     args = parser.parse_args()
 
     # 1) Read the JSON data

--- a/testzeus_hercules/config.py
+++ b/testzeus_hercules/config.py
@@ -593,7 +593,7 @@ class BaseConfigManager:
         # LLM Model Configuration defaults
         # --------------------------------------------------
         # Core model settings
-        self._config.setdefault("LLM_MODEL_NAME", "gpt-4o")
+        self._config.setdefault("LLM_MODEL_NAME", "gpt-5.4")
         self._config.setdefault("LLM_MODEL_API_KEY", None)  # No default for security
         self._config.setdefault("LLM_MODEL_API_TYPE", "openai")
         # self._config.setdefault("LLM_MODEL_BASE_URL", "https://api.openai.com/v1")

--- a/testzeus_hercules/core/memory/dynamic_ltm.py
+++ b/testzeus_hercules/core/memory/dynamic_ltm.py
@@ -162,7 +162,7 @@ I work strictly with data that has been explicitly stored in my memory.""",
                 "task": "qa",
                 "docs_path": self.static_data_list,
                 "chunk_token_size": 20000,
-                "model": self.llm_config.get("config_list", [{}])[0].get("model", "gpt-5.4-mini"),
+                "model": self.llm_config.get("config_list", [{}])[0].get("model", "gpt-5.4-nano"),
                 "collection_name": f"ad{namespace}",  # Use namespace in collection name
                 "get_or_create": self.reuse_vector_db,  # Use config to determine get_or_create
                 "persist_dir": self.vector_db_path,  # Set persistence directory

--- a/testzeus_hercules/core/memory/dynamic_ltm.py
+++ b/testzeus_hercules/core/memory/dynamic_ltm.py
@@ -162,7 +162,7 @@ I work strictly with data that has been explicitly stored in my memory.""",
                 "task": "qa",
                 "docs_path": self.static_data_list,
                 "chunk_token_size": 20000,
-                "model": self.llm_config.get("config_list", [{}])[0].get("model", "gpt-4o-mini"),
+                "model": self.llm_config.get("config_list", [{}])[0].get("model", "gpt-5.4-mini"),
                 "collection_name": f"ad{namespace}",  # Use namespace in collection name
                 "get_or_create": self.reuse_vector_db,  # Use config to determine get_or_create
                 "persist_dir": self.vector_db_path,  # Set persistence directory

--- a/testzeus_hercules/core/simple_hercules.py
+++ b/testzeus_hercules/core/simple_hercules.py
@@ -127,7 +127,7 @@ class SimpleHercules:
         Args:
             planner_agent_config: dict[str, Any]: A dictionary containing the configuration parameters for the planner agent. For example:
                 {
-                    "model_name": "gpt-4o",
+                    "model_name": "gpt-5.4",
                     "model_api_key": "",
                     "model_base_url": null,
                     "system_prompt": ["optional prompt unless you want to use the built in"],

--- a/testzeus_hercules/utils/junit_helper.py
+++ b/testzeus_hercules/utils/junit_helper.py
@@ -315,7 +315,7 @@ def run_test() -> None:
     cost_metric = {
         "usage_including_cached_inference": {
             "total_cost": 0.12923500000000002,
-            "gpt-4o-2024-08-06": {
+            "gpt-5.4-2026-03-05": {
                 "cost": 0.12923500000000002,
                 "prompt_tokens": 45362,
                 "completion_tokens": 1583,
@@ -324,7 +324,7 @@ def run_test() -> None:
         },
         "usage_excluding_cached_inference": {
             "total_cost": 0.11612000000000003,
-            "gpt-4o-2024-08-06": {
+            "gpt-5.4-2026-03-05": {
                 "cost": 0.11612000000000003,
                 "prompt_tokens": 41220,
                 "completion_tokens": 1307,

--- a/testzeus_hercules/utils/llm_helper.py
+++ b/testzeus_hercules/utils/llm_helper.py
@@ -22,7 +22,7 @@ from testzeus_hercules.utils.response_parser import parse_response
 from testzeus_hercules.utils.model_utils import adapt_llm_params_for_model
 
 DEFAULT_LMM_SYS_MSG = """You are a helpful AI assistant."""
-DEFAULT_MODEL = "gpt-4o"
+DEFAULT_MODEL = "gpt-5.4"
 
 
 class MultimodalConversableAgent(ConversableAgent):


### PR DESCRIPTION
- Changed default model from `gpt-4o` to `gpt-5.4` in `cdp_journey_script.py`, `generate_api_functional_gherkin_test.py`, `generate_api_security_gherkin_test.py`, `vir_migration_script.py`, and `config.py`.
- Updated model references in `run_hercules_docker.ps1`, `simple_hercules.py`, `dynamic_ltm.py`, and `llm_helper.py`.
- Adjusted cost metrics in `junit_helper.py` to reflect the new model version.

This update ensures consistency in model usage across the project.