### PR TITLE
fix: add --config support for YAML/JSON Hercules config files

### DIFF
--- a/tests/test_cli_config_file.py
+++ b/tests/test_cli_config_file.py
@@ -1,71 +1,150 @@
+import importlib.util
+import json
+import logging
 import os
-from pathlib import Path
-from typing import Generator
+import pathlib
+import sys
+import types
+from typing import Any, Generator
 
 import pytest
 
-from testzeus_hercules.config import SingletonConfigManager, set_global_conf
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT / "testzeus_hercules" / "config.py"
 
 
-class TestCliConfigFile:
-    @pytest.fixture(autouse=True)
-    def setup_teardown(self) -> Generator[None, None, None]:
-        os.environ["IS_TEST_ENV"] = "true"
-        SingletonConfigManager.reset_instance()
-        yield
-        SingletonConfigManager.reset_instance()
+def _clear_testzeus_modules() -> None:
+    for name in list(sys.modules):
+        if name == "testzeus_hercules" or name.startswith("testzeus_hercules."):
+            del sys.modules[name]
 
-    def test_yaml_config_file_is_loaded_via_cli_flag(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        config_file = tmp_path / "hercules.config.yaml"
-        config_file.write_text(
-            "\n".join(
-                [
-                    f"input_file: {tmp_path / 'input' / 'test.feature'}",
-                    f"output_path: {tmp_path / 'output'}",
-                    f"test_data_path: {tmp_path / 'test_data'}",
-                    f"agents_llm_config_file: {tmp_path / 'agents_llm_config.json'}",
-                    "agents_llm_config_file_ref_key: huggingface",
-                    "browser: chromium",
-                    "headless: false",
-                    "save_proofs: true",
-                ]
-            ),
-            encoding="utf-8",
-        )
 
-        monkeypatch.setattr("sys.argv", ["testzeus-hercules", "--config", str(config_file)])
+def _load_config_module(argv: list[str]) -> Any:
+    """Load testzeus_hercules.config in isolation, stubbing internal package
+    init so we don't drag in core/agents/tools (which require system deps)."""
+    _clear_testzeus_modules()
 
-        config = set_global_conf({}, ignore_env=False, override=True)
+    pkg = types.ModuleType("testzeus_hercules")
+    pkg.__path__ = [str(ROOT / "testzeus_hercules")]
+    sys.modules["testzeus_hercules"] = pkg
 
-        assert config.get_config()["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "input" / "test.feature")
-        assert config.get_config()["JUNIT_XML_BASE_PATH"] == str(tmp_path / "output")
-        assert config.get_config()["TEST_DATA_PATH"] == str(tmp_path / "test_data")
-        assert config.get_config()["AGENTS_LLM_CONFIG_FILE"] == str(tmp_path / "agents_llm_config.json")
-        assert config.get_config()["AGENTS_LLM_CONFIG_FILE_REF_KEY"] == "huggingface"
-        assert config.get_config()["BROWSER_TYPE"] == "chromium"
-        assert config.get_config()["HEADLESS"] == "false"
-        assert config.get_config()["TAKE_SCREENSHOTS"] == "true"
+    utils_pkg = types.ModuleType("testzeus_hercules.utils")
+    utils_pkg.__path__ = [str(ROOT / "testzeus_hercules" / "utils")]
+    sys.modules["testzeus_hercules.utils"] = utils_pkg
 
-    def test_cli_flags_override_config_file_values(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        config_file = tmp_path / "hercules.config.yaml"
-        config_file.write_text(
-            f"input_file: {tmp_path / 'from-config.feature'}\nllm_model: from-config\nllm_model_api_key: secret\n",
-            encoding="utf-8",
-        )
+    logger_mod = types.ModuleType("testzeus_hercules.utils.logger")
+    logger_mod.logger = logging.getLogger("test-config")
+    sys.modules["testzeus_hercules.utils.logger"] = logger_mod
 
-        monkeypatch.setattr(
-            "sys.argv",
+    timestamp_mod = types.ModuleType("testzeus_hercules.utils.timestamp_helper")
+    timestamp_mod.get_timestamp_str = lambda: "0"
+    sys.modules["testzeus_hercules.utils.timestamp_helper"] = timestamp_mod
+
+    telemetry_mod = types.ModuleType("testzeus_hercules.telemetry")
+
+    class EventData:  # noqa: D401
+        pass
+
+    class EventType:  # noqa: D401
+        pass
+
+    telemetry_mod.EventData = EventData
+    telemetry_mod.EventType = EventType
+    telemetry_mod.add_event = lambda *args, **kwargs: None
+    sys.modules["testzeus_hercules.telemetry"] = telemetry_mod
+
+    old_argv = sys.argv[:]
+    sys.argv = argv[:]
+    try:
+        spec = importlib.util.spec_from_file_location("testzeus_hercules.config", CONFIG_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["testzeus_hercules.config"] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.argv = old_argv
+
+
+@pytest.fixture(autouse=True)
+def _set_test_env() -> Generator[None, None, None]:
+    os.environ["IS_TEST_ENV"] = "true"
+    yield
+
+
+def test_yaml_config_file_is_loaded_via_cli_flag(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "hercules.config.yaml"
+    config_file.write_text(
+        "\n".join(
             [
-                "testzeus-hercules",
-                "--config",
-                str(config_file),
-                "--input-file",
-                str(tmp_path / "from-cli.feature"),
-            ],
-        )
+                f"input_file: {tmp_path / 'input' / 'test.feature'}",
+                f"output_path: {tmp_path / 'output'}",
+                f"test_data_path: {tmp_path / 'test_data'}",
+                f"agents_llm_config_file: {tmp_path / 'agents_llm_config.json'}",
+                "agents_llm_config_file_ref_key: huggingface",
+                "browser: chromium",
+                "headless: false",
+                "save_proofs: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
-        config = set_global_conf({}, ignore_env=False, override=True)
+    module = _load_config_module(["testzeus-hercules", "--config", str(config_file)])
+    cfg = module.get_global_conf().get_config()
 
-        assert config.get_config()["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "from-cli.feature")
-        assert config.get_config()["LLM_MODEL_NAME"] == "from-config"
-        assert config.get_config()["LLM_MODEL_API_KEY"] == "secret"
+    assert cfg["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "input" / "test.feature")
+    assert cfg["JUNIT_XML_BASE_PATH"] == str(tmp_path / "output")
+    assert cfg["TEST_DATA_PATH"] == str(tmp_path / "test_data")
+    assert cfg["AGENTS_LLM_CONFIG_FILE"] == str(tmp_path / "agents_llm_config.json")
+    assert cfg["AGENTS_LLM_CONFIG_FILE_REF_KEY"] == "huggingface"
+    assert cfg["BROWSER_TYPE"] == "chromium"
+    assert cfg["HEADLESS"] == "false"
+    assert cfg["TAKE_SCREENSHOTS"] == "true"
+
+
+def test_json_config_file_is_loaded_via_cli_flag(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "hercules.config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "input_file": str(tmp_path / "input.feature"),
+                "llm_model": "from-json",
+                "llm_model_api_key": "json-key",
+                "headless": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    module = _load_config_module(["testzeus-hercules", "--config", str(config_file)])
+    cfg = module.get_global_conf().get_config()
+
+    assert cfg["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "input.feature")
+    assert cfg["LLM_MODEL_NAME"] == "from-json"
+    assert cfg["LLM_MODEL_API_KEY"] == "json-key"
+    assert cfg["HEADLESS"] == "true"
+
+
+def test_cli_flags_override_config_file_values(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "hercules.config.yaml"
+    config_file.write_text(
+        f"input_file: {tmp_path / 'from-config.feature'}\nllm_model: from-config\nllm_model_api_key: secret\n",
+        encoding="utf-8",
+    )
+
+    module = _load_config_module(
+        [
+            "testzeus-hercules",
+            "--config",
+            str(config_file),
+            "--input-file",
+            str(tmp_path / "from-cli.feature"),
+        ]
+    )
+    cfg = module.get_global_conf().get_config()
+
+    assert cfg["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "from-cli.feature")
+    assert cfg["LLM_MODEL_NAME"] == "from-config"
+    assert cfg["LLM_MODEL_API_KEY"] == "secret"

--- a/tests/test_cli_config_file.py
+++ b/tests/test_cli_config_file.py
@@ -1,0 +1,71 @@
+import os
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from testzeus_hercules.config import SingletonConfigManager, set_global_conf
+
+
+class TestCliConfigFile:
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self) -> Generator[None, None, None]:
+        os.environ["IS_TEST_ENV"] = "true"
+        SingletonConfigManager.reset_instance()
+        yield
+        SingletonConfigManager.reset_instance()
+
+    def test_yaml_config_file_is_loaded_via_cli_flag(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        config_file = tmp_path / "hercules.config.yaml"
+        config_file.write_text(
+            "\n".join(
+                [
+                    f"input_file: {tmp_path / 'input' / 'test.feature'}",
+                    f"output_path: {tmp_path / 'output'}",
+                    f"test_data_path: {tmp_path / 'test_data'}",
+                    f"agents_llm_config_file: {tmp_path / 'agents_llm_config.json'}",
+                    "agents_llm_config_file_ref_key: huggingface",
+                    "browser: chromium",
+                    "headless: false",
+                    "save_proofs: true",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("sys.argv", ["testzeus-hercules", "--config", str(config_file)])
+
+        config = set_global_conf({}, ignore_env=False, override=True)
+
+        assert config.get_config()["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "input" / "test.feature")
+        assert config.get_config()["JUNIT_XML_BASE_PATH"] == str(tmp_path / "output")
+        assert config.get_config()["TEST_DATA_PATH"] == str(tmp_path / "test_data")
+        assert config.get_config()["AGENTS_LLM_CONFIG_FILE"] == str(tmp_path / "agents_llm_config.json")
+        assert config.get_config()["AGENTS_LLM_CONFIG_FILE_REF_KEY"] == "huggingface"
+        assert config.get_config()["BROWSER_TYPE"] == "chromium"
+        assert config.get_config()["HEADLESS"] == "false"
+        assert config.get_config()["TAKE_SCREENSHOTS"] == "true"
+
+    def test_cli_flags_override_config_file_values(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        config_file = tmp_path / "hercules.config.yaml"
+        config_file.write_text(
+            f"input_file: {tmp_path / 'from-config.feature'}\nllm_model: from-config\nllm_model_api_key: secret\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "testzeus-hercules",
+                "--config",
+                str(config_file),
+                "--input-file",
+                str(tmp_path / "from-cli.feature"),
+            ],
+        )
+
+        config = set_global_conf({}, ignore_env=False, override=True)
+
+        assert config.get_config()["INPUT_GHERKIN_FILE_PATH"] == str(tmp_path / "from-cli.feature")
+        assert config.get_config()["LLM_MODEL_NAME"] == "from-config"
+        assert config.get_config()["LLM_MODEL_API_KEY"] == "secret"

--- a/testzeus_hercules/config.py
+++ b/testzeus_hercules/config.py
@@ -5,6 +5,7 @@ import json
 import os
 from typing import Any, Dict, List, Literal, Optional, Union
 
+import yaml
 from dotenv import load_dotenv
 from testzeus_hercules.utils.logger import logger
 from testzeus_hercules.utils.timestamp_helper import get_timestamp_str
@@ -115,12 +116,81 @@ class BaseConfigManager:
     # Internal Helpers
     # -------------------------------------------------------------------------
 
+    def _load_cli_config_file(self, config_file_path: str) -> None:
+        """Load CLI config file values into the config dictionary before env merging.
+
+        Supported formats: YAML (.yaml/.yml) and JSON (.json).
+        CLI flags still win because they are applied after this method runs.
+        """
+        if not os.path.exists(config_file_path):
+            logger.error(f"Config file not found: {config_file_path}")
+            exit(1)
+
+        _, ext = os.path.splitext(config_file_path)
+        with open(config_file_path, "r", encoding="utf-8") as f:
+            if ext.lower() in {".yaml", ".yml"}:
+                loaded_config = yaml.safe_load(f) or {}
+            elif ext.lower() == ".json":
+                loaded_config = json.load(f)
+            else:
+                logger.error("Unsupported config file format. Use .yaml, .yml, or .json")
+                exit(1)
+
+        if not isinstance(loaded_config, dict):
+            logger.error("Config file must contain a top-level mapping/object")
+            exit(1)
+
+        key_mapping = {
+            "input_file": "INPUT_GHERKIN_FILE_PATH",
+            "output_path": "JUNIT_XML_BASE_PATH",
+            "test_data_path": "TEST_DATA_PATH",
+            "project_base": "PROJECT_SOURCE_ROOT",
+            "llm_model": "LLM_MODEL_NAME",
+            "llm_model_api_key": "LLM_MODEL_API_KEY",
+            "llm_model_base_url": "LLM_MODEL_BASE_URL",
+            "llm_model_api_type": "LLM_MODEL_API_TYPE",
+            "llm_temperature": "LLM_MODEL_TEMPERATURE",
+            "agents_llm_config_file": "AGENTS_LLM_CONFIG_FILE",
+            "agents_llm_config_file_ref_key": "AGENTS_LLM_CONFIG_FILE_REF_KEY",
+            "enable_portkey": "ENABLE_PORTKEY",
+            "portkey_api_key": "PORTKEY_API_KEY",
+            "portkey_strategy": "PORTKEY_STRATEGY",
+            "bulk": "EXECUTE_BULK",
+            "reuse_vector_db": "REUSE_VECTOR_DB",
+            "browser": "BROWSER_TYPE",
+            "browser_type": "BROWSER_TYPE",
+            "browser_channel": "BROWSER_CHANNEL",
+            "browser_path": "BROWSER_PATH",
+            "browser_version": "BROWSER_VERSION",
+            "headless": "HEADLESS",
+            "record_video": "RECORD_VIDEO",
+            "take_screenshots": "TAKE_SCREENSHOTS",
+            "save_proofs": "TAKE_SCREENSHOTS",
+            "capture_network": "CAPTURE_NETWORK",
+            "ignore_certificate_errors": "IGNORE_CERTIFICATE_ERRORS",
+            "log_level": "LOG_LEVEL",
+            "dont_close_browser": "DONT_CLOSE_BROWSER",
+            "token_verbose": "TOKEN_VERBOSE",
+            "sandbox_tenant_id": "SANDBOX_TENANT_ID",
+            "sandbox_custom_injections": "SANDBOX_CUSTOM_INJECTIONS",
+        }
+
+        for key, value in loaded_config.items():
+            mapped_key = key_mapping.get(key, key.upper())
+            if isinstance(value, bool):
+                self._config[mapped_key] = str(value).lower()
+            elif value is not None:
+                self._config[mapped_key] = str(value)
+
+        logger.info(f"Loaded CLI config file: {config_file_path}")
+
     def _parse_arguments(self) -> None:
         """
         Parse Hercules-specific command-line arguments
         and place them into the environment for consistency.
         """
         parser = argparse.ArgumentParser(description="Hercules: The World's First Open-Source AI Agent for End-to-End Testing")
+        parser.add_argument("--config", type=str, help="Path to a YAML/JSON Hercules config file.", required=False)
         # Basic path configuration
         parser.add_argument("--input-file", type=str, help="Path to the input file.", required=False)
         parser.add_argument(
@@ -283,6 +353,9 @@ class BaseConfigManager:
 
         # Parse known args; ignore unknown if you have other custom arguments
         args, _ = parser.parse_known_args()
+
+        if args.config:
+            self._load_cli_config_file(args.config)
 
         # Basic path configuration
         if args.input_file:


### PR DESCRIPTION
## Summary
Add missing `--config` CLI support so Hercules can load YAML/JSON config files.

## Root cause
The CLI did not define a `--config` argument.
Because argument parsing used `parse_known_args()`, the unknown `--config` flag was silently ignored instead of failing fast.

As a result, users expected values like `input_file`, `output_path`, `test_data_path`, and `agents_llm_config_file` to be loaded from `hercules.config.yaml`, but Hercules continued with defaults/env values.

## Changes
- add `--config` argument to the CLI parser
- support loading `.yaml`, `.yml`, and `.json`
- map common config-file keys to internal config/env keys
- preserve precedence: config file first, explicit CLI flags override it
- add regression tests for config loading and CLI override behavior

## Validation
- reproduced the bug by confirming `--config` was not defined and therefore ignored
- added regression tests for config loading and CLI override behavior
- verified modified files compile successfully with:

```bash
python3 -m compileall testzeus_hercules/config.py tests/test_cli_config_file.py
```

Closes #64
