### PR TITLE
release: version 1.0.0 🚀

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testzeus-hercules"
-version = "0.2.0"
+version = "1.0.0"
 description = "Hercules: The World's First Open-Source AI Agent for End-to-End Testing"
 authors = [{ name = "Shriyansh Agnihotri", email = "shriyansh@testzeus.com" }]
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Release 1.0.0 🚀

Version bump `0.2.0` → `1.0.0`. This is a major release because it ships the **LangGraph (LangChain) migration** (#141) — a rewrite of the Hercules orchestration engine from ag2 (AutoGen) to LangGraph.

### Highlights from the LangGraph migration

- **Replaced ag2/AutoGen orchestration with a LangGraph `StateGraph`** — agents are now typed graph nodes with explicit edges instead of free-form chat participants; flow control moves from a `max_rounds` counter to Python-defined conditional routing.
- **Introduced `AgentState` TypedDict** — replaces the implicit shared message list with fully typed, inspectable state snapshots at each node boundary.
- **Migrated tool binding to `StructuredTool` + `langchain_tools.py` registry** — `llm.bind_tools()` separates tool registration from invocation, replacing the `@register_for_llm` / `@register_for_execution` decorator pattern.
- **Strict planner JSON contract** — `plan`, `next_step`, `target_helper`, and `terminate` fields enforce a deterministic inter-agent protocol.
- **New `litellm_helper.py`** — LiteLLM is now the provider layer for model calls.
- **Rewrote MCP session lifecycle** — raw `mcp` client sessions with async context managers for stdio, SSE, and streamable-HTTP transports, replacing the ag2 MCP adapter.
- **Bugfixes** — fixed HumanMessage/assistant role-mapping corruption in chat logs and overly aggressive context trimming that made the planner lose the original task.

### Release mechanics

The `1.0.0` tag was already pushed and the "Upload Python Package" workflow has published the release to PyPI. The direct push of the bump commit to `main` was rejected by the repository rule requiring pull requests, so this PR carries that commit instead.

Note: prefer a merge commit (not squash) so the `1.0.0` tag stays on `main`'s history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)